### PR TITLE
Add another route for live tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ app = Flask(__name__)
 def get_alerts():
   return jsonify(get_alerts_data())
 
+@app.route('/')
 @app.route('/rtf')
 def get_rtf():
   return jsonify(get_rtf_data())


### PR DESCRIPTION
- Serve live tracking route through `/` as well as `/rtf` so we can deploy microservice and test live tracking first