### PR TITLE
Change refresh time to 5 seconds

### DIFF
--- a/src/live_tracking.py
+++ b/src/live_tracking.py
@@ -56,7 +56,7 @@ def fetch_rtf(event):
     rtf_data = parse_xml_to_json(rq.text)
   except:
     print(traceback.format_exc())
-  threading.Timer(1, fetch_rtf, [event]).start()
+  threading.Timer(5, fetch_rtf, [event]).start()
 
 def get_rtf_data():
   return rtf_data


### PR DESCRIPTION
Tom wants us to change the refresh rate for GTFS realtime so that we aren't refreshing every second so I changed it to 5. This shouldn't have a big impact because according to Tom `buses only refresh every 30 seconds`.