### PR TITLE
Fix rtf key issue

### DIFF
--- a/src/live_tracking.py
+++ b/src/live_tracking.py
@@ -34,9 +34,11 @@ def parse_xml_to_json(xml):
 
       if isinstance(stop_time_updates, type([])):
           for stop_update in stop_time_updates:
+              if stop_update['schedule_relationship'] == 'NoData':
+                  continue
               stop_id = stop_update['StopId']
               stop_updates[stop_id] = stop_update['Arrival']['Delay']
-      else:
+      elif stop_time_updates['schedule_relationship'] != 'NoData':
           stop_id = stop_time_updates['StopId']
           stop_updates[stop_id] = stop_time_updates['Arrival']['Delay']
 


### PR DESCRIPTION
Often times, we get Key Errors when trying to access `stop_update['Arrival']['Delay']` since sometimes the `stop_update` might actually contain no data