### PR TITLE
Replace /gtfs-date with /gtfs-feed-info for more descriptive date info

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import os
 from flask import Flask, jsonify
 
 from src.alerts import fetch_alerts, get_alerts_data
-from src.gtfs import fetch_gtfs, get_gtfs_data, get_gtfs_date_updated
+from src.gtfs import fetch_gtfs, get_gtfs_data, get_gtfs_feed_info
 from src.live_tracking import fetch_rtf, get_rtf_data
 from src.stops import fetch_stops, get_stops_data
 
@@ -28,11 +28,9 @@ def get_rtf():
 def get_all_stops():
   return jsonify(get_stops_data())
 
-@app.route('/gtfs-date')
+@app.route('/gtfs-feed-info')
 def get_gtfs_date():
-  if get_gtfs_date_updated():
-    return jsonify(get_gtfs_date_updated())
-  return jsonify('Unknown when GTFS was last updated')
+  return jsonify(get_gtfs_feed_info())
 
 if __name__ == '__main__':
   alerts_event, gtfs_event, rtf_event, stops_event = [threading.Event() for i in range(4)]

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -20,7 +20,7 @@ def extract_gtfs():
             route = {}
             for index, column in enumerate(column_names):
                 route[column] = row[index]
-                gtfs_data.append(route)
+            gtfs_data.append(route)
 
 
 def get_gtfs_feed_info():
@@ -30,7 +30,7 @@ def get_gtfs_feed_info():
         column_names = next(csv_reader)
         for row in csv_reader:
             for index, column in enumerate(column_names):
-                if column in ["feed_start_date", "feed_end_date", "feed_version"]:
+                if column in {"feed_start_date", "feed_end_date", "feed_version"}:
                     gtfs_feed_info[column] = row[index]
     return gtfs_feed_info
 

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -1,15 +1,10 @@
 import csv
 
-# from subprocess import PIPE, Popen, STDOUT
-# import datetime
-# import threading
-# import zipfile
-
 TCAT_NY_US = "tcat-ny-us"
 TEN_SECONDS = 10
 
 gtfs_data = []
-date_updated = None
+gtfs_feed_info = {}
 
 
 def fetch_gtfs(event):
@@ -25,11 +20,19 @@ def extract_gtfs():
             route = {}
             for index, column in enumerate(column_names):
                 route[column] = row[index]
-            gtfs_data.append(route)
+                gtfs_data.append(route)
 
 
-def get_gtfs_date_updated():
-    return date_updated
+def get_gtfs_feed_info():
+    global gtfs_feed_info
+    with open(f"{TCAT_NY_US}/feed_info.txt") as csv_file:
+        csv_reader = csv.reader(csv_file, delimiter=",")
+        column_names = next(csv_reader)
+        for row in csv_reader:
+            for index, column in enumerate(column_names):
+                if column in ["feed_start_date", "feed_end_date", "feed_version"]:
+                    gtfs_feed_info[column] = row[index]
+    return gtfs_feed_info
 
 
 def get_gtfs_data():


### PR DESCRIPTION
## Overview
Last semester, I created a `/gtfs-date` endpoint when we did automatic fetching of GTFS data to know when exactly we last fetched the data. However, we are no longer doing automatic fetching, but I discovered that there is a `feed_info.txt` in our GTFS data that is actually super helpful. It tells us the feed start date, feed end date, and feed version. So, I decided to scrap the old `/gtfs-date` with a new `/gtfs-feed-info`.

And now that we know when the GTFS data is no longer valid for (feed end date), it'd be great to have `integration` ping this endpoint to:
* slack the transit-integration-results channel that the GTFS data is about to expire
* build a new image of the microservice and ghopper and deploy them to their servers

I go more in detail about why this is necessary in the git issue linked below.

I also ran the pre-commit formatter!

## Changes Made
I used a csv reader to parse the `feed_info.txt` file in our `tcat-ny-us` folder that holds our GTFS data. I got the dates that correspond only to the keys "feed_start_date", "feed_end_date", and "feed_version." Then, I updated our return variable to a list that actually contains these values, as well as the endpoint name to make more sense.


## Test Coverage
Tested this locally on Postman. Because we will never upload an image of the micro-service without the GTFS data already in it, and because this endpoint doesn't have anything to do with the client, there's no urgent need to deploy this onto the servers to see if it works. I will still however, let it sit a couple of days on the dev server before putting it on prod once I get enough feedback on this PR.


## Next Steps & Related Issues
This is intended to get [the issue in `integration`](https://github.com/cuappdev/integration/issues/14) moving.


## Screenshots

<details>

  <summary>Postman result from running locally</summary>
  
</details>
<img width="414" alt="Screen Shot 2019-10-16 at 5 43 56 PM" src="https://user-images.githubusercontent.com/13739525/66962488-207a4280-f03f-11e9-8259-d3adbb4eb5d3.png">
