### PR TITLE
Add `/vehicles` endpoint to help replace `/tracking`, which helps clients draw buses 

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from src.alerts import fetch_alerts, get_alerts_data
 from src.gtfs import fetch_gtfs, get_gtfs_data, get_gtfs_feed_info
 from src.live_tracking import fetch_rtf, get_rtf_data
 from src.stops import fetch_stops, get_stops_data
+from src.vehicles import fetch_vehicles, get_vehicles_data
 
 app = Flask(__name__)
 
@@ -37,17 +38,24 @@ def get_gtfs_date():
     return jsonify(get_gtfs_feed_info())
 
 
+@app.route("/vehicles")
+def get_vehicles():
+    return jsonify(get_vehicles_data())
+
+
 if __name__ == "__main__":
-    alerts_event, gtfs_event, rtf_event, stops_event = [threading.Event() for i in range(4)]
+    alerts_event, gtfs_event, rtf_event, stops_event, vehicles_event = [threading.Event() for i in range(5)]
     fetch_alerts(alerts_event)
     fetch_gtfs(gtfs_event)
     fetch_rtf(rtf_event)
     fetch_stops(stops_event)
+    fetch_vehicles(vehicles_event)
     time.sleep(1)
     app.run(host="0.0.0.0", port=5000)
 elif __name__ == "app":
-    alerts_event, gtfs_event, rtf_event, stops_event = [threading.Event() for i in range(4)]
+    alerts_event, gtfs_event, rtf_event, stops_event, vehicles_event = [threading.Event() for i in range(5)]
     fetch_alerts(alerts_event)
     fetch_gtfs(gtfs_event)
     fetch_rtf(rtf_event)
     fetch_stops(stops_event)
+    fetch_vehicles(vehicles_event)

--- a/src/live_tracking.py
+++ b/src/live_tracking.py
@@ -13,6 +13,7 @@ def parse_protobuf(rq):
     entity_dict = {}
     feed = gtfs_realtime_pb2.FeedMessage()
     feed.ParseFromString(rq.read())
+    vehicle_id = None
     for entity in feed.entity:
         if entity.HasField("trip_update"):
             if entity.trip_update.HasField("vehicle"):

--- a/src/vehicles.py
+++ b/src/vehicles.py
@@ -1,0 +1,53 @@
+import threading
+import traceback
+
+import gtfs_realtime_pb2
+import urllib.request
+
+VEHICLES_URL = "https://realtimetcatbus.availtec.com/InfoPoint/GTFS-Realtime.ashx?&Type=VehiclePosition&serverid=0"
+
+vehicles_data = None
+
+
+def parse_protobuf(rq):
+    entity_dict = {}
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.ParseFromString(rq.read())
+    for entity in feed.entity:
+        vehicle_id = entity.id
+        if entity.HasField("vehicle"):
+            timestamp = entity.vehicle.timestamp
+            congestion_level = entity.vehicle.congestion_level
+            if entity.vehicle.HasField("trip"):
+                trip_id = entity.vehicle.trip.trip_id
+                route_id = entity.vehicle.trip.route_id
+            if entity.vehicle.HasField("position"):
+                longitude = entity.vehicle.position.longitude
+                latitude = entity.vehicle.position.latitude
+                bearing = entity.vehicle.position.bearing
+                speed = entity.vehicle.position.speed
+        entity_dict[vehicle_id] = {
+            "bearing": bearing,
+            "congestion_level": congestion_level,
+            "latitude": latitude,
+            "longitude": longitude,
+            "routeID": route_id,
+            "speed": speed,
+            "timestamp": timestamp,
+            "tripID": trip_id,
+        }
+    return entity_dict
+
+
+def fetch_vehicles(event):
+    global vehicles_data
+    try:
+        rq = urllib.request.urlopen(VEHICLES_URL)
+        vehicles_data = parse_protobuf(rq)
+    except:
+        print(traceback.format_exc())
+    threading.Timer(30, fetch_vehicles, [event]).start()
+
+
+def get_vehicles_data():
+    return vehicles_data


### PR DESCRIPTION
Sorry if I added too many reviewers, everyone goes MIA on me so I wanted to spam as many people as possible. Please help me get this approved ASAP so Android can ship within this semester!!

## Overview
Currently, `/tracking` is an endpoint for `ithaca-transit-backend`, and right now it isn't returning data for the buses, and so the iOS and Android clients can't draw the buses on the map. This is the first step towards refactoring this, and this is my entire plan for addressing this issue:
1) We need to have the microservice parse protobuf for vehicle information from [this TCAT third-party endpoint](https://realtimetcatbus.availtec.com/InfoPoint/GTFS-Realtime.ashx?&Type=VehiclePosition&debug=true&serverid=0) (I've linked the debug JSON version so you can view it, but I am currently parsing the binary file using the protobuf API). 
2) We need to set up a new endpoint `/vehicle` on `ithaca-transit-backend` that uses this new `ithaca-transit-microservice`'s `/vehicles` which takes in a `tripID` and `stopID` and returns important info like `longitude` and `latitude` which will help draw the buses. Note the singular and plural difference for `vehicle` on each repository.
3) We need to update the swagger docs that mentions that `/tracking` should no longer be used, and instead `/vehicle` should be used.

This PR is step 1, I will be making two more PRs soon on `ithaca-transit-backend` that addresses steps 2 and 3.

Note: Kevin made a super good comment about why we couldn't just make a `/vehicle` endpoint on the microservice, but the point is that we want the Node backend to handle multiple requests at the same time for a `/vehicle`. Python is too slow for this, and I think this is the same reason why we return all of `/rtf` instead of giving `/delay` like we do in the Node backend. 

## Changes Made
I've added a new `/vehicles` endpoint that parses the endpoint I linked above using the protobuf API. It's pretty straightforward; all it does is return a dictionary where the keys are vehicle IDs and values are the information about the vehicles.



## Test Coverage
Works locally. Will be deploying on dev server to see if it works. Wouldn't mess with what's currently deployed on our servers anyway, since it's just adding an endpoint.



## Next Steps 
Steps 2 and 3 ASAP!

## Screenshots 
<img width="533" alt="Screen Shot 2020-04-04 at 2 07 45 PM" src="https://user-images.githubusercontent.com/13739525/78461430-aa65a880-767d-11ea-91d7-7ec42d27cba4.png">