### PR TITLE
Rename bus info to follow ithaca-transit-backend naming convention

### DIFF
--- a/src/vehicles.py
+++ b/src/vehicles.py
@@ -28,7 +28,7 @@ def parse_protobuf(rq):
                 speed = entity.vehicle.position.speed
         entity_dict[vehicle_id] = {
             "bearing": bearing,
-            "congestion_level": congestion_level,
+            "congestionLevel": congestion_level,
             "latitude": latitude,
             "longitude": longitude,
             "routeID": route_id,


### PR DESCRIPTION
A minor oopsies that I just realized when making the PR for the new `/tracking` upgrades.