### PR TITLE
Catch twitter exception for updating duplicate statuses 

### DIFF
--- a/src/twitter.py
+++ b/src/twitter.py
@@ -49,4 +49,7 @@ class TwitterAPI:
         """Makes a request to post tweets with the given alerts"""
         for alert in self.get_new_alerts(alerts):
             status = self.format_alert_status(alert)
-            self.api.update_status(status=status)
+            try:
+                self.api.update_status(status=status)
+            except tweepy.error.TweepError:
+                continue

--- a/src/vehicles.py
+++ b/src/vehicles.py
@@ -28,7 +28,7 @@ def parse_protobuf(rq):
                 speed = entity.vehicle.position.speed
         entity_dict[vehicle_id] = {
             "bearing": bearing,
-            "congestion_level": congestion_level,
+            "congestionLevel": congestion_level,
             "latitude": latitude,
             "longitude": longitude,
             "routeID": route_id,


### PR DESCRIPTION
## Overview
Tried running the microservice once in a blue moon and came across an error -- it doesn't stop the server from running but it should definitely be caught. Basically whenever you run the service locally, you could be uploading duplicate tweets from TCAT's alerts system, so we want to just catch the exception and ignore it.